### PR TITLE
Set `pydev_message` only if `additional_info` exists.

### DIFF
--- a/pytest_pycharm.py
+++ b/pytest_pycharm.py
@@ -21,7 +21,8 @@ def pytest_exception_interact(node, call, report):
         frames_by_id = dict([(id(frame), frame) for frame in frames])
         frame = frames[-1]
         exception = (exctype, value, traceback)
-        thread.additional_info.pydev_message = 'test fail'
+        if hasattr(thread, "additional_info"):
+            thread.additional_info.pydev_message = "test fail"
         try:
             debugger = pydevd.debugger
         except AttributeError:


### PR DESCRIPTION
When running a remote interpreter I sometimes encountered the following error:
```python
AttributeError: '_MainThread' object has no attribute 'additional_info'
```

I'm not sure what's the purpose of setting this message, but conditionally skipping it seems to have no negative effects - PyCharm enters the breakpoint instead of crashing the test session.